### PR TITLE
Bump Babel runtime to patched release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "styled-components": "6.4.0"
       },
       "devDependencies": {
+        "@babel/runtime": "7.26.10",
         "@vitejs/plugin-react": "^4.3.4",
         "@vitest/coverage-v8": "^4.1.4",
         "jsdom": "^26.1.0",
@@ -291,11 +292,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
-      "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2523,9 +2524,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/rollup": {
       "version": "4.60.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "node": ">=20"
   },
   "devDependencies": {
+    "@babel/runtime": "7.26.10",
     "@vitejs/plugin-react": "^4.3.4",
     "@vitest/coverage-v8": "^4.1.4",
     "jsdom": "^26.1.0",


### PR DESCRIPTION
## Summary
This PR updates the Babel runtime to the patched `7.26.10` release so Renovate and security scanners stop flagging the vulnerable transitive dependency.

## What changed
- Pinned `@babel/runtime` to `7.26.10` in `package.json`
- Refreshed `package-lock.json` so the installed tree resolves to the patched runtime

## Validation
- `npm test`
- `npm run build`

## Scope note
`src/Feed.js` and `src/Instafeed.js` remain untracked and were not included in this branch.